### PR TITLE
change to unidirectional signal called "Incremental"

### DIFF
--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -70,7 +70,7 @@ buffer the entire HTTP request, the client will not start receiving application
 messages from the server until the client closes the request, effectively
 disrupting the intended incremental processing of the request.
 
-To prevent such deadlocks, this document specifies the "Incremental" HTTP header
+To prevent such behavior, this document specifies the "Incremental" HTTP header
 field, which instructs HTTP intermediaries to begin forwarding the HTTP message
 downstream before receiving the complete message.
 

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -17,6 +17,13 @@ normative:
 
 informative:
   PROXY-STATUS: RFC9209
+  SSE:
+    target: https://html.spec.whatwg.org/multipage/server-sent-events.html
+    title: Server-Sent Events
+    author:
+     -
+        org: WHATWG
+
 
 
 --- abstract
@@ -36,7 +43,7 @@ message to be received before acting.
 Some applications are specifically designed to take advantage of this
 capability.
 
-For example, Server-Sent Events (SSE) uses a long-running HTTP response, where
+For example, Server-Sent Events {{SSE}} uses a long-running HTTP response, where
 the server continually sends notifications as they become available.
 
 In the case of Chunked Oblivious HTTP Messages

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -68,7 +68,7 @@ receiving any portion of the HTTP response.
 In the case of Chunked Oblivious HTTP Messages, when an intermediary tries to
 buffer the entire HTTP request, the client will not start receiving application
 messages from the server until the client closes the request, effectively
-disrupting the intended bi-directional communication.
+disrupting the intended incremental processing of the request.
 
 To prevent such deadlocks, this document specifies the "Incremental" HTTP header
 field, which instructs HTTP intermediaries to begin forwarding the HTTP message

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -114,7 +114,7 @@ common for intermediaries to impose limits on the maximum number of concurrent
 HTTP requests that they forward, while buffering requests that exceed this
 limit.
 
-Such intermediaries may apply a more restrictive concurrency limit to requests
+Such intermediaries could apply a more restrictive concurrency limit to requests
 marked as incremental to ensure that capacity remains available for
 non-incremental requests, even when the maximum number of incremental requests
 is reached. This approach helps balance the processing of different types of

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -70,7 +70,7 @@ buffer the entire HTTP request, the client will not start receiving application
 messages from the server until the client closes the request, effectively
 disrupting the intended incremental processing of the request.
 
-To prevent such behavior, this document specifies the "Incremental" HTTP header
+To help avoid such behavior, this document specifies the "Incremental" HTTP header
 field, which instructs HTTP intermediaries to begin forwarding the HTTP message
 downstream before receiving the complete message.
 

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -1,5 +1,5 @@
 ---
-title: "Streaming Requests on HTTP"
+title: "Incremental HTTP Messages"
 docname: draft-kazuho-httpbis-streaming-requests-latest
 category: std
 wg: httpbis
@@ -21,40 +21,51 @@ informative:
 
 --- abstract
 
-This document specifies the "Request-Streaming" HTTP request header field, which
-instructs HTTP intermediaries to begin forwarding the request and the
-corresponding response before the HTTP message body is received completely.
+This document specifies the "Incremental" HTTP header field, which instructs
+HTTP intermediaries to forward the HTTP message incrementally.
 
 
 --- middle
 
 # Introduction
 
-HTTP {{!HTTP=RFC9110}} is a request-response protocol that allows servers to
-start transmitting a response before the entire HTTP request has been received.
-Some applications, such as Chunked Oblivious HTTP Messages
-{{?CHUNKED-OHTTP=I-D.ietf-ohai-chunked-ohttp}}, exploit this capability to turn
-a single HTTP request-response pair into a medium for bi-directional
-communication, on which multiple application-defined request-response message
-pairs are exchanged.
+HTTP {{!HTTP=RFC9110}} permits receivers to begin processing portions of HTTP
+messages as they arrive, rather than requiring them to wait for the entire HTTP
+message to be received before acting.
 
-However, this approach is fragile when HTTP intermediaries are involved. HTTP
-intermediaries are not only allowed but are frequently deployed to buffer
-complete HTTP requests before forwarding them to the backend server
+Some applications are specifically designed to take advantage of this
+capability.
+
+For example, Server-Sent Events (SSE) uses a long-running HTTP response, where
+the server continually sends notifications as they become available.
+
+In the case of Chunked Oblivious HTTP Messages
+{{?CHUNKED-OHTTP=I-D.ietf-ohai-chunked-ohttp}}, the client opens an HTTP request
+and incrementally sends application messages, while the server begins responding
+even before the HTTP request is fully complete. In this way, the HTTP
+request-response pair effectively serves as a bi-directional communication
+channel.
+
+However, these applications are fragile when HTTP intermediaries are involved.
+This is because HTTP intermediaries are not only permitted but are frequently
+deployed to buffer complete HTTP messages before forwarding them downstream
 ({{Section 7.6 of HTTP}}).
 
-Should such a buffering HTTP intermediary be present between the client and the
-server, the application in question fails to function as intended. Upon sending
-the HTTP header section and the initial application message, the client awaits a
-response while keeping the HTTP request open for subsequent application
-messages. Concurrently, the intermediary delays forwarding until the HTTP
-request is fully received. This misalignment leads to a deadlock that prevents
-the exchange of application-defined messages, effectively disrupting the
-intended bi-directional communication.
+If such a buffering HTTP intermediary exists between the client and the server,
+these applications may fail to function as intended.
 
-To prevent such deadlocks, this document specifies the "Request-Streaming" HTTP
-request header field, that instructs HTTP intermediaries to begin forwarding the
-HTTP request downstream before receiving the complete request.
+In the case of Server-Sent Events, when an intermediary tries to buffer the HTTP
+response completely before forwarding it, the client can time out before
+receiving any portion of the HTTP response.
+
+In the case of Chunked Oblivious HTTP Messages, when an intermediary tries to
+buffer the entire HTTP request, the client will not start receiving application
+messages from the server until the client closes the request, effectively
+disrupting the intended bi-directional communication.
+
+To prevent such deadlocks, this document specifies the "Incremental" HTTP header
+field, which instructs HTTP intermediaries to begin forwarding the HTTP message
+downstream before receiving the complete message.
 
 
 # Conventions and Definitions
@@ -64,26 +75,27 @@ HTTP request downstream before receiving the complete request.
 The term Boolean is imported from {{!STRUCTURED-FIELDS=RFC8941}}.
 
 
-# The Request-Streaming Header Field
+# The Incremental Header Field
 
-The Request-Streaming request header field expresses the client's intent for
-HTTP intermediaries to start forwarding the request to downstream servers before
-the entire request is received.
+The Incremental HTTP header field expresses the sender's intent for HTTP
+intermediaries to start forwarding the message downstream before the entire
+message is received.
 
 This header field has just one valid value of type Boolean: "?1".
 
 ~~~
-Request-Streaming = ?1
+Incremental = ?1
 ~~~
 
-Upon receiving a header section that includes the Request-Streaming header
-field, HTTP intermediaries SHOULD NOT buffer the entire request before
-forwarding it. Instead, intermediaries SHOULD establish an HTTP channel to
-downstream servers, transmit the header section, and continuously forward the
-bytes of the request body as they arrive.
+Upon receiving a header section that includes the Incremental header field, HTTP
+intermediaries SHOULD NOT buffer the entire message before forwarding it.
+Instead, intermediaries SHOULD transmit the header section downstream and
+continuously forward the bytes of the message body as they arrive.
 
-Similarly, intermediaries SHOULD forward the bytes of the response body to the
-clients as they are received.
+The Incremental HTTP header field applies to each HTTP message. Therefore, if
+both the HTTP request and response need to be forwarded incrementally, the
+Incremental HTTP header field MUST be set for both the HTTP request and the
+response.
 
 
 # Security Considerations
@@ -95,27 +107,16 @@ common for intermediaries to impose limits on the maximum number of concurrent
 HTTP requests that they forward, while buffering requests that exceed this
 limit.
 
-Such intermediaries may apply a more restrictive concurrency limit to streaming
-requests to ensure that there remains capacity to process non-streaming
-requests, even when the maximum number of long-lived streaming requests is
-reached. This approach helps balance the processing of different types of
-requests and maintains service availability across all request types.
+Such intermediaries may apply a more restrictive concurrency limit to requests
+marked as incremental to ensure that capacity remains available for
+non-incremental requests, even when the maximum number of incremental requests
+is reached. This approach helps balance the processing of different types of
+requests and maintains service availability across all requests.
 
-When rejecting streaming requests due to reaching the concurrency limit,
+When rejecting incremental requests due to reaching the concurrency limit,
 intermediaries SHOULD respond with a 503 Service Unavailable error, accompanied
-with a connection_limit_reached Proxy-Status response header field
+by a connection_limit_reached Proxy-Status response header field
 ({{Section 2.3.12 of PROXY-STATUS}}).
-
-
-## Rejecting Streaming Requests
-
-Some intermediaries buffer the entire HTTP request or response body to inspect
-the payload as a whole. If these intermediaries cannot tolerate streaming
-requests as indicated by the Request-Streaming request header field, they SHOULD
-reject these streaming requests with a 403 Forbidden response
-({{Section 15.5.4 of HTTP}}). Rejecting these requests explicitly is preferable
-to buffering the HTTP body in hopes that it will eventually be closed by the
-sender.
 
 
 # IANA Considerations

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -104,6 +104,12 @@ both the HTTP request and response need to be forwarded incrementally, the
 Incremental HTTP header field MUST be set for both the HTTP request and the
 response.
 
+The Incremental field is advisory. Intermediaries that are unaware of the field
+or that do not support the field might buffer messages, even when explicitly
+requested otherwise.  Clients and servers therefore cannot expect all
+intermediaries to understand and respect a request to deliver messages
+incrementally. Clients can rely on prior knowledge or probe for support on
+individual resources.
 
 # Security Considerations
 

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -48,7 +48,7 @@ the server continually sends notifications as they become available.
 
 In the case of Chunked Oblivious HTTP Messages
 {{?CHUNKED-OHTTP=I-D.ietf-ohai-chunked-ohttp}}, the client opens an HTTP request
-and incrementally sends application messages, while the server begins responding
+and incrementally sends application messages, while the server can start responding
 even before the HTTP request is fully complete. In this way, the HTTP
 request-response pair effectively serves as a bi-directional communication
 channel.

--- a/draft-kazuho-httpbis-streaming-requests.md
+++ b/draft-kazuho-httpbis-streaming-requests.md
@@ -62,7 +62,7 @@ If such a buffering HTTP intermediary exists between the client and the server,
 these applications may fail to function as intended.
 
 In the case of Server-Sent Events, when an intermediary tries to buffer the HTTP
-response completely before forwarding it, the client can time out before
+response completely before forwarding it, the client might time out before
 receiving any portion of the HTTP response.
 
 In the case of Chunked Oblivious HTTP Messages, when an intermediary tries to


### PR DESCRIPTION
As discussed in #2, the header field now applies to the HTTP message to which it is attached. Also, the name is changed to Incremental.

Closes #2.